### PR TITLE
Removed income brackets from 'Census Predicted' charts

### DIFF
--- a/ntp/app/static/js/charts.js
+++ b/ntp/app/static/js/charts.js
@@ -186,7 +186,7 @@ function reloadCharts() {
                     item.data.unshift(['F', 0]);
                 }
 
-                drawPieChart(elementId, item);
+                drawPieChart(elementId, item, item.income_level);
 
                 //Types of charts (ethnicity and gender) corresponds to
                 //the value of $('select#demographics')
@@ -233,16 +233,18 @@ function reloadCharts() {
                         })
                 };
 
+                var comparisonChartTitle = '';
+                
                 var elementId2 = 'chart-2' + key;
                 $('#charts-container2').append('<div id="' + elementId2 + '" class="chart"></div>');
-                drawPieChart(elementId2, comparisonChart);
+                drawPieChart(elementId2, comparisonChart, comparisonChartTitle);
             });
 
         }
     });
 };
 
-function drawPieChart(elementId, chartData) {
+function drawPieChart(elementId, chartData, title) {
     $('#' + elementId).highcharts({
         chart: {
             plotBackgroundColor: null,
@@ -253,7 +255,7 @@ function drawPieChart(elementId, chartData) {
             enabled: false
         },
         title: {
-            text: chartData.income_level
+            text: title
         },
         tooltip: {
             pointFormat: '{name}: <b>{point.percentage:.1f}%</b>'


### PR DESCRIPTION
Removed the repetitious income brackets from the 'Census Predicted' charts (e.g. 'Lower Income (Less than $33,000).  This makes sense in the desktop version, but on smaller widths the columns get smashed into a single column, so we might want to do some bootstrap magic to add the title, but hide it until we get down to a single column. This is the last bullet on #54.