### PR TITLE
Min-width for graphs and cleared selectors at top

### DIFF
--- a/ntp/app/static/css/main.css
+++ b/ntp/app/static/css/main.css
@@ -4,8 +4,38 @@
    Author's custom styles
    ========================================================================== */
 
-.navbar {
-	background-color:#374F9A;
+body {
+	padding-top: 50px;
+  	padding-bottom: 20px;	
+}
+
+p {
+	font-size: 16pt;
+	font-family: Arial;
+	margin-right: auto;
+	margin-left: auto;
+	text-align: justify;
+}
+
+.jumbotron {
+	margin-right: auto;
+	margin-left: auto;
+	padding-right: 7.5%;
+	padding-left: 7.5%;
+
+	background-color: #FFF;
+	background-image:url(../img/nashville.png);
+	background-size: cover;
+	background-repeat: no-repeat;
+	
+	height: 250px;
+	width: 100%;
+	position: relative;
+}
+
+.jumbotron a {
+	color: #EF5325;
+	max-width: 1000px;
 }
 
 .jumbotron h1 {
@@ -14,131 +44,10 @@
 
 }
 
-.jumbotron {
-	margin-right: auto;
-	margin-left: auto;
-	padding-right: 7.5%;
-	padding-left: 7.5%;
-}
-
-.container {
-	width:80%;
-}
-
-#graph {
-	padding-top: 2cm;
-	width: 100%
-
-}
-
-.jumbotron a {
-	color: #EF5325;
-	max-width: 1000px;
-}
-
-#ntp {
-	color:#AB509E;
-}
-
-.main-content h4 {
-	color:#374F9A;
-}
-
-.navbar-brand, .navbar-brand:hover {
-	color:#FFF;
-	text-shadow:none;
-}
-
-
 .jumbotron img {
   position: absolute;
   right: 5px;
   top: -40px;
-}
-
-.col-md-2 {
-	padding-top: 1cm;
-}
-
-.form {
-  margin-bottom: 20px;
-}
-
-select #department {
-	max-width: 10px;
-}
-
-.jumbotron {
-	background-color: #FFF;
-	background-image:url(../img/nashville.png);
-	background-size: cover;
-	background-repeat: no-repeat;
-	
-  height: 250px;
-  position: relative;
-  margin-bottom: 130px;
-	width: 100%;
-}
-
-.fields {
-  margin-bottom: 10px;
-}
-
-.filter-container {
-	position:fixed;
-	top:350px;
-	left:50px;
-	padding:10px;
-	z-index:5;
-}
-
-.filter-container select {
-	height: 32px;
-	width: 190px;
-	font-size: 18px;
-}
-
-.charts {
-  background: red;
-  height: 400px;
-}
-
-
-#charts-container {
-	min-width: 300px;
-	max-width: 500.66px;
-	min-height: 400px;
-	margin: 0 auto;
-}
-
-#charts-container2 {
-	min-width: 300px;
-	max-width: 500.66px;
-	min-height: 400px;
-	margin: 0 auto;
-}
-
-p {
-	font-size: 14pt;
-	font-family: Arial;
-	margin-right: auto;
-	margin-left: auto;
-	text-align: justify;
-}
-
-#charts-container p {
-	font-size: 16pt;
-	font-family: Arial;
-	margin-top: 0.8in;
-	margin-right: auto;
-	margin-left: auto;
-	text-align: justify;
-}
-
-.chart {
-	margin:20px auto;
-	margin-bottom:100px;
-	clear: both;
 }
 
 .loading {
@@ -150,10 +59,48 @@ p {
 	height:400px;
 }
 
-.wrapper {
-  padding: 0;
-  max-width: 1020px;
-  margin: 0 auto;
+.navbar {
+	background-color:#374F9A;
+}
+
+.navbar-brand, .navbar-brand:hover {
+	color:#FFF;
+	text-shadow:none;
+}
+
+.pie-charts p {
+	font-size: 16pt;
+	font-family: Arial;
+	margin-top: 0.8in;
+	margin-right: auto;
+	margin-left: auto;
+	text-align: justify;
+}
+
+#graph-filters {
+	padding-bottom: 2em;
+}
+
+#graph-filters select {
+	height: 32px;
+	font-size: 18px;
+}
+
+#home-link:visited {
+	color: white;
+}
+
+#line-graphs {
+	padding-top: 2cm;
+	width: 100%
+}
+
+#main-content h4 {
+	color:#374F9A;
+}
+
+#ntp {
+	color:#AB509E;
 }
 
 @media (max-width: 900px) {
@@ -164,7 +111,7 @@ p {
 
 @media (max-width: 760px) {
   .jumbotron img {
-    width: 30%;
+    width: 25%;
     top: 0;
   }
 
@@ -174,8 +121,9 @@ p {
 }
 
 @media (max-width : 780px) {
-  .main-content {
-    margin-top: -90px;
+  #main {
+  	/* Hack to get the content to ignore the 'Metro Humans Relations Commision' image
+  	hanging out of the nav */
   }
 }
 

--- a/ntp/app/static/js/charts.js
+++ b/ntp/app/static/js/charts.js
@@ -14,63 +14,10 @@ $.getJSON("/api/departments", function (response) {
     $.each(deps, function (val, text) {
         departments.append($("<option></option>").val(text).html(text));
     });
-    $('<option>').addClass('select-option')
-    .val('')
-    .html('--Select a department--')
-    .prependTo(departments);
 });
 
 // Highcharts options 
 $(function () {
-    //var overall_time = {
-    //        series: [{'color': '#EF5325',
-    //          'data': [0.7071847189060126, 0.7022729817489642, 0.7019874944171505],
-    //          'name': 'White (Not of Hispanic Origin)'},
-    //         {'color': '#AB509E',
-    //          'data': [0.2605817234642935, 0.2641361549658493, 0.26429209468512727],
-    //          'name': 'Black'},
-    //         {'color': '#ACAE4E',
-    //          'data': [0.01812459301063599, 0.018922852983988356, 0.019205002233139794],
-    //          'name': 'Hispanic'},
-    //         {'color': '#ACAE4E',
-    //          'data': [0.005317994356414152, 0.0050386294927779645, 0.004912907548012505],
-    //          'name': 'Unknown'},
-    //         {'color': '#ACAE4E',
-    //          'data': [0.007271543303668331, 0.007725898555592879, 0.007815989280928986],
-    //          'name': 'Asian or Pacific Islander'},
-    //         {'color': '#ACAE4E',
-    //          'data': [0.001302365964836119, 0.001455604075691412, 0.0013398838767306833],
-    //          'name': 'American Indian/Alaskan Native'},
-    //         {'color': '#ACAE4E',
-    //          'data': [0.00010853049706967658,
-    //           0.00011196954428395476,
-    //           0.00011165698972755694],
-    //          'name': 'Hawaiian or Pacific Islander'},
-    //         {'color': '#ACAE4E',
-    //          'data': [0.00010853049706967658,
-    //           0.0003359086328518643,
-    //           0.00033497096918267083],
-    //          'name': 'Two or More Races'}],
-    //        time: ["2014 - December", "2015 - March", "2015 - April"]
-    //    };
-
-
-    // $.ajax({
-    //        type: "GET",
-    //        url: "/api/temporal",
-    //        contentType: "application/json",
-    //        data: {},
-    //        success: function (data) {
-    //            drawLineGraph('graph-container', {series: data.temporal.series}, data.temporal.axis);
-    //            console.log({series: data.temporal.series});
-    //        }
-    //    }
-    //)
-
-    //drawLineGraph('graph-container', {series: overall_time.series}, overall_time.time);
-    //drawLineGraph('graph-container1', {series: overall_time.series}, overall_time.time);
-    //drawLineGraph('graph-container2', {series: overall_time.series}, overall_time.time);
-    //drawLineGraph('graph-container3', {series: overall_time.series}, overall_time.time);
 
     // Load "About" page and line charts
     aboutPage();
@@ -112,13 +59,12 @@ function aboutPage()
     });
 
     // Clear graph content and about page if there
-    $('#charts-container').empty()
-    $('#charts-container2').empty()
+    $('#metro-pie-charts').empty()
+    $('#census-pie-charts').empty()
 
-    $('#graph').empty();
-    $('#about-message-container').empty();
+    $('#about-message').empty();
 
-    $('#about-message-container')
+    $('#about-message')
         .prepend(
             "<p>" +
             "In January 2015, the Metro Human Relations Commission (MHRC) released the IncluCivics Report, " +
@@ -143,13 +89,12 @@ function reloadCharts() {
     var department_name = $('select#department').val();
     var demographic_type = $('select#demographics').val();
 
+    $('#metro-pie-charts').html('');
+    $('#metro-pie-charts').html('<div class="loading">Loading...</div>');
 
-    $('#charts-container').html('');
-    $('#charts-container').html('<div class="loading">Loading...</div>');
-    $('#graph').empty();
-
-    // Remove about message when you reload charts
-    $('#about-message-container').empty();
+    // Remove about message and line graphs when you reload charts
+    $('#line-graphs').empty();
+    $('#about-message').empty();
 
     var request_data = JSON.stringify({name: department_name, attribute: demographic_type});
     $.ajax({
@@ -160,10 +105,10 @@ function reloadCharts() {
         success: function (data) {
             var charts = data.attribute;
 
-            $('#charts-container').html('').append(
+            $('#metro-pie-charts').html('').append(
                 "<h3 align='center'>Metro Demographics</h3>"
             );
-            $('#charts-container2').html('').append(
+            $('#census-pie-charts').html('').append(
                 "<h3 align='center'>Census Predicted</h3>"
             );
 
@@ -173,8 +118,8 @@ function reloadCharts() {
                                 'Hawaiian or Pacific Islander,Two or More Races,F,M').split(',');
 
                 var elementId = 'chart-' + key;
-                $('#charts-container').append(
-                    '<div id="' + elementId + '" class="chart">CHART</div>'
+                $('#metro-pie-charts').append(
+                    '<div id="' + elementId + '" class="charts">CHART</div>'
                 );
                 item.data.sort(function (a,b) { 
                     console.log( sortOrder.indexOf(a[0]) - sortOrder.indexOf(b[0]) );
@@ -236,7 +181,7 @@ function reloadCharts() {
                 var comparisonChartTitle = '';
                 
                 var elementId2 = 'chart-2' + key;
-                $('#charts-container2').append('<div id="' + elementId2 + '" class="chart"></div>');
+                $('#census-pie-charts').append('<div id="' + elementId2 + '" class="chart"></div>');
                 drawPieChart(elementId2, comparisonChart, comparisonChartTitle);
             });
 
@@ -283,7 +228,6 @@ function drawPieChart(elementId, chartData, title) {
 
 function drawLineGraph(elementId, chartData, axes, title)
 {
-
      $('<div>').attr('id', elementId).highcharts({
         chart: {
             backgroundColor: null,
@@ -327,5 +271,5 @@ function drawLineGraph(elementId, chartData, axes, title)
         },
         // Series is of form {name: "Line Name", data: ["positionally", "relevant", fields]}
         series: chartData.series
-    }).appendTo('#graph');
+    }).appendTo('#line-graphs');
 }

--- a/ntp/app/templates/index.html
+++ b/ntp/app/templates/index.html
@@ -6,17 +6,11 @@
 <head>
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-<title></title>
+<title>Inclucivics</title>
 <meta name="description" content="">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
 <link rel="stylesheet" href="../static/css/bootstrap.min.css">
-<style>
-body {
-  padding-top: 50px;
-  padding-bottom: 20px;
-}
-</style>
 <link rel="stylesheet" href="../static/css/bootstrap-theme.min.css">
 <link rel="stylesheet" href="../static/css/main.css">
 <script src="https://code.jquery.com/jquery-2.1.3.min.js"></script>
@@ -44,40 +38,34 @@ body {
     </div>
   </nav>
 
-  <!-- Main jumbotron for a primary marketing message or call to action -->
   <section class="jumbotron">
     <div class="header-text col-md-12">
       <h1>IncluCivics</h1>
       <p>Brought to you by <a href="http://www.codefornashville.org">Code for Nashville</a><br> and the <a href="#" id="ntp">Nashville Transparency Project</a></p>
       <img src="{{ url_for('static', filename='img/logo.png')}}" /> 
     </div>
-      <div class="header col-md-2">
-      <h4>Department</h4>
-
-      <select id="department"></select>
-          <h4>Demographics:</h4>
-      <select id="demographics">
-        <option value="" class="select-option">--Select a demographic--</option>
-        <option value="ethnicity">Race/Ethnicity</option>
-        <option value="gender">Sex</option>
-      </select>
-
-    </div>
   </section>
-  <section class="main-content">
-    <div class="container">
-        <div id="about-message-container"></div>
-        <div id="graph"></div>
-            <div class="col-md-6">
-                <div id="charts-container">
-                </div>
-            </div>
-            <div>
-                <div class="col-md-6">
-                    <div id="charts-container2">
-                    </div>
-                </div>
-            </div>
+
+  <section id="main" class="container">
+    <div class="row">
+      <div id="graph-filters" class="col-xs-12">
+        <h4>Department</h4>
+        <select id="department">
+          <option value="" class="select-option">--Select--</option>
+        </select>
+        <h4>Demographics:</h4>
+        <select id="demographics">
+          <option value="" class="select-option">--Select--</option>
+          <option value="ethnicity">Race/Ethnicity</option>
+          <option value="gender">Sex</option>
+        </select>
+      </div>
+      <div id="main-content" class="col-xs-12">
+        <div id="about-message" class="col-xs-12"></div>
+        <div id="line-graphs" class="col-xs-12"></div>
+        <div id="metro-pie-charts" class="col-md-6 pie-charts"></div>
+        <div id="census-pie-charts" class="col-md-6 pie-charts"></div>
+      </div>
     </div>
   </section>
   <footer>


### PR DESCRIPTION
Updated the site to improve mobile responsiveness. Addressed some of the issues in #57. Tested it using Chrome's mobile emulators, but proof is in the pudding, so there may be more fixes down the line once we deploy and test the real deal.

Wrapped line-graphs in a row class div to give it a min width.  Added Bootstrap col classes to the selector container to clear it from the "About" message.

Cleaned up the markup, removing extraneous divs and css, and made some of the ids more meaningful. For example, replaced `id='charts-container2'` with `id='census-pie-charts`. Organized css selectors in order of descending specificity, and alphabetically.