### PR TITLE
Update header

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ transparency into employee demographics at Nashville's Metro Government.
 2. Clone repo, download `vagrant up`
 3. `vagrant ssh` will log you into the VM
 4. `cd /vagrant/ntp`
-5. `sudo python run_server.py` will add all the incluvics data and launch the python webserver available on localhost:8080
+5. `sudo python run_server.py` will add all the incluvics data and launch the python webserver available on localhost:8082
 
 ### How To Deploy Changes
 1. Make a PR (Pull Request) and get it merged

--- a/ntp/app/static/css/main.css
+++ b/ntp/app/static/css/main.css
@@ -79,6 +79,10 @@ footer {
 	text-shadow:none;
 }
 
+.jumbotron-title:hover {
+  color: #489DB8;
+}
+
 .pie-charts p {
 	font-size: 16pt;
 	font-family: Arial;

--- a/ntp/app/templates/index.html
+++ b/ntp/app/templates/index.html
@@ -30,7 +30,7 @@
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>
         </button>
-        <a class="navbar-brand" href="#" id="home-link">Nashville Transparency Project</a>
+        <a class="navbar-brand" href="/" id="home-link">IncluCivics</a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
 
@@ -40,9 +40,9 @@
 
   <section class="jumbotron">
     <div class="header-text col-md-12">
-      <h1>IncluCivics</h1>
-      <p>Brought to you by <a href="http://www.codefornashville.org">Code for Nashville</a><br> and the <a href="#" id="ntp">Nashville Transparency Project</a></p>
-      <img src="{{ url_for('static', filename='img/logo.png')}}" /> 
+      <a href="/" class="jumbotron-title"><h1>IncluCivics</h1></a>
+      <p>Brought to you by <a href="http://www.codefornashville.org">Code for Nashville</a>
+      <a href="/"><img src="{{ url_for('static', filename='img/logo.png')}}" /></a> 
     </div>
   </section>
 


### PR DESCRIPTION
Link back to the homepage (easy reset of filters) on title and navbar, plus some styling on those things.

Removed reference to the Nashville Transparency Project (thought that Jon mentioned it wasn't a thing, we can put them back in) as well.

<img width="1280" alt="screen shot 2015-10-20 at 7 29 22 pm" src="https://cloud.githubusercontent.com/assets/8376505/10624713/e2aa923a-7760-11e5-9103-adb7a64162c2.png">

The logo on the right also links back to the homepage.
