### PR TITLE
refactor(travis.yml): Removing travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: python
-python:
-  - "2.7"
-# command to install dependencies
-install: "sudo python setup.py install"
-# We skip this step for now - until we have real tests to run
-script:	 true
-

--- a/travis.yml
+++ b/travis.yml
@@ -1,7 +1,0 @@
-language: python
-python:
-  - "2.7"
-# command to install dependencies
-install: "sudo python setup.py install"
-# we don't have any tests to run (beyond starting the server and not sure that would be kosher). Setting script to true skips the test step
-script: true


### PR DESCRIPTION
Migrating to wercker for CI/CD.  I want to remove the travis files so
that it is not recognized by the travis service and I run a single build
using wercker.

Issue #90